### PR TITLE
建築年の前処理でコケていた部分を解消しました

### DIFF
--- a/package/preprocess.py
+++ b/package/preprocess.py
@@ -110,6 +110,7 @@ class Preprocessor(_Rename, _Encoder):
         df.loc[df["era_name"] == "昭和", "建築年"] = df["和暦年数"] + 1925
         df.loc[df["era_name"] == "平成", "建築年"] = df["和暦年数"] + 1988
         df["建築年"] = pd.to_numeric(df["建築年"], errors="coerce")
+        df = df.drop("和暦年数", axis=1)
         return df
 
     def direction_to_int(self, column: str) -> pd.DataFrame:

--- a/package/preprocess.py
+++ b/package/preprocess.py
@@ -105,10 +105,10 @@ class Preprocessor(_Rename, _Encoder):
         df = self.df.copy()
         df["建築年"].dropna(inplace=True)
         df["建築年"] = df["建築年"].str.replace("戦前", "昭和20年")
-        df["年号"] = df["建築年"].str[:2]
+        df["era_name"] = df["建築年"].str[:2]
         df["和暦年数"] = df["建築年"].str[2:].str.strip("年").fillna(0).astype(int)
-        df.loc[df["年号"] == "昭和", "建築年"] = df["和暦年数"] + 1925
-        df.loc[df["年号"] == "平成", "建築年"] = df["和暦年数"] + 1988
+        df.loc[df["era_name"] == "昭和", "建築年"] = df["和暦年数"] + 1925
+        df.loc[df["era_name"] == "平成", "建築年"] = df["和暦年数"] + 1988
         df["建築年"] = pd.to_numeric(df["建築年"], errors="coerce")
         return df
 

--- a/package/sklearns.py
+++ b/package/sklearns.py
@@ -19,7 +19,7 @@ from preprocess.Preprocessor import all
 
 df = train["y"]
 
-predata = pd.concat([train.drop("y", axis=1), test])
+predata = pd.concat([train.drop("y", axis=1), test], ignore_index=True)
 predata = predata.all("onehot")
 
 prep_train = pd.concat([df, predata.iloc[:len(train), :]], axis=1)


### PR DESCRIPTION
1. 連結したあとDataFrameのインデックスをリセットしないとpandasの文字列処理のタイミングでコケるみたいです．
sklearns.pyでconcatする部分にオプション引数を加えることで対処しました．
2. 列名がASCII文字列であることを失念していたので，その部分の記述を追加しました．